### PR TITLE
Fix segfaults from combination of reverse_search_and_line_edition

### DIFF
--- a/src/cores/line_edition/ctrl_left_right.c
+++ b/src/cores/line_edition/ctrl_left_right.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ctrl_left_right.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dthan <dthan@student.hive.fi>              +#+  +:+       +#+        */
+/*   By: ihwang <ihwang@student.hive.fi>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/04/20 00:15:39 by ihwang            #+#    #+#             */
-/*   Updated: 2021/03/19 22:20:49 by rklein           ###   ########.fr       */
+/*   Updated: 2021/03/25 13:12:19 by ihwang           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,8 @@ int			ctrl_right(t_l *l)
 {
 	int	index;
 
+	if (l->rs)
+		ft_reverse_search_reset(l);
 	index = ft_index_calc(l);
 	if (index < l->nb && !ft_isspace(l->line[index]) && \
 	ctrl_right_pos_check(l->line, index))
@@ -46,6 +48,8 @@ int			ctrl_left(t_l *l)
 	int	i;
 	int	index;
 
+	if (l->rs)
+		ft_reverse_search_reset(l);
 	i = 0;
 	while (ft_isspace(l->line[i]))
 		i++;

--- a/src/cores/line_edition/parse_key.c
+++ b/src/cores/line_edition/parse_key.c
@@ -6,7 +6,7 @@
 /*   By: ihwang <ihwang@student.hive.fi>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 11:41:34 by rklein            #+#    #+#             */
-/*   Updated: 2021/03/19 22:22:06 by rklein           ###   ########.fr       */
+/*   Updated: 2021/03/25 13:15:38 by ihwang           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,9 +57,9 @@ int		parse_line_edition_key(char buf[BUFF_LINE_EDITION], t_l *line_edition)
 {
 	if (ft_strequ(buf, BACKSLASH_KEY))
 		return (bs_key(line_edition));
-	else if (ft_strequ(buf, CUT_KEY))
+	else if (ft_strequ(buf, CUT_KEY) && line_edition->rs == 0)
 		return (cutting(line_edition));
-	else if (ft_strequ(buf, PASTE_KEY))
+	else if (ft_strequ(buf, PASTE_KEY) && line_edition->rs == 0)
 		return (paste(line_edition, NULL, NULL));
 	else if (ft_strequ(buf, HOME_KEY))
 		return (home_key(line_edition));


### PR DESCRIPTION
The changes are about
1. Blocking `copy` and `paste` keys when `reverse_search` is being executed. (The rest of the line_edition keys should be recognized)
2. Resetting reverse_search info for ctrl+left and ctrl+right keys.