### PR TITLE
Add a file access checking

### DIFF
--- a/src/features/builtin/ft_cd_utilities/ft_cd_is_root_dir.c
+++ b/src/features/builtin/ft_cd_utilities/ft_cd_is_root_dir.c
@@ -17,7 +17,7 @@ char	is_root_dir(char *path)
 	t_stat root;
 	t_stat path_stat;
 
-	if (path == NULL)
+	if (path == NULL || access(path, F_OK) != 0)
 		return (FALSE);
 	stat("/", &root);
 	stat(path, &path_stat);


### PR DESCRIPTION
Add simple file access checking to prevent accessing to un-initialized stack pointer. (`t_stat path_stat` in is_root_dir() function)